### PR TITLE
Fix tests and Django 1.8 warnings

### DIFF
--- a/referral/middleware.py
+++ b/referral/middleware.py
@@ -17,7 +17,7 @@ class ReferrerMiddleware():
             except Referrer.DoesNotExist:
                 if settings.AUTO_CREATE:
                     referrer = Referrer(name=referrer_name)
-                    if request.user and request.user.is_authenticated():
+                    if hasattr(request, 'user') and request.user and request.user.is_authenticated():
                         referrer.user = self.request.user
                     referrer.save()
                 if referrer is not None and settings.AUTO_ASSOCIATE:

--- a/referral/tests/factories.py
+++ b/referral/tests/factories.py
@@ -3,24 +3,31 @@ import factory
 from referral.compat import User
 from referral.models import Campaign, Referrer, UserReferrer
 
+
 class UserFactory(factory.django.DjangoModelFactory):
-    FACTORY_FOR = User
+    class Meta:
+        model = User
+
 
 class CampaignFactory(factory.django.DjangoModelFactory):
-    FACTORY_FOR = Campaign
+    class Meta:
+        model = Campaign
 
     name = factory.Sequence(lambda n: "Test Campaign %s" % n)
     description = "Some long test description"
 
+
 class ReferrerFactory(factory.django.DjangoModelFactory):
-    FACTORY_FOR = Referrer
+    class Meta:
+        model = Referrer
 
     name = factory.Sequence(lambda n: "Test Referrer %s" % n)
     description = "Some long test description"
 
+
 class UserReferrerFactory(factory.django.DjangoModelFactory):
-    FACTORY_FOR = UserReferrer
+    class Meta:
+        model = UserReferrer
 
     user = factory.LazyAttribute(lambda a: UserFactory())
     referrer = factory.LazyAttribute(lambda a: ReferrerFactory())
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 
 Django>=1.6.0
 coverage
-factory-boy==2.4.1
+factory-boy==2.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,64 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist =
-    py34-1.7.X,
-    py27-1.7.X,
-    py34-1.6.X,
-    py27-1.6.X,
-    py34-1.5.X,
-    py27-1.5.X,
-    py27-1.4.X
+envlist = py{27,34}-1.{5,6,7,8}.X
 
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE=referral.tests.settings
     PYTHONPATH={toxinidir}
+deps =
+    1.8.X: django>=1.8, <1.9
+    1.7.X: django>=1.7, <1.8
+    1.6.X: django>=1.6, <1.7
+    1.5.X: django>=1.5, <1.6
+    1.5.X: django-discover-runner
+    factory_boy==2.5.2
 commands =
     django-admin.py --version
     django-admin.py test referral
-
-[testenv:py34-1.7.X]
-basepython = python3.4
-deps =
-    django>=1.7, <1.8
-    factory_boy==2.4.1
-
-[testenv:py27-1.7.X]
-basepython = python2.7
-deps =
-    django>=1.7, <1.8
-    factory_boy==2.4.1
-
-[testenv:py34-1.6.X]
-basepython = python3.4
-deps =
-    django>=1.6, <1.7
-    factory_boy==2.4.1
-
-[testenv:py27-1.6.X]
-basepython = python2.7
-deps =
-    django>=1.6, <1.7
-    factory_boy==2.4.1
-
-[testenv:py34-1.5.X]
-basepython = python3.4
-deps =
-    django-discover-runner
-    django>=1.5, <1.6
-    factory_boy==2.4.1
-
-[testenv:py27-1.5.X]
-basepython = python2.7
-deps =
-    django-discover-runner
-    django>=1.5, <1.6
-    factory_boy==2.4.1
-
-[testenv:py27-1.4.X]
-basepython = python2.7
-deps =
-    django-discover-runner
-    django>=1.4, <1.5
-    factory_boy==2.4.1


### PR DESCRIPTION
- Fixed tests broken by one of the recent middleware changes
- Cleaned up tox.ini, added Django 1.8 tests
- Upgraded factory_boy to avoid warnings when running under Django 1.8, such as:

```
/Users/jeremy/.virtualenvs/ucap/lib/python2.7/site-packages/factory/django.py:97: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  from django.db.models import loading as django_loading
```
